### PR TITLE
fix: DOS - lack of init fund

### DIFF
--- a/src/test/DOS.sol
+++ b/src/test/DOS.sol
@@ -16,7 +16,7 @@ function testDOS() public {
 
     address alice = vm.addr(1);
     address bob = vm.addr(2);
-    vm.deal(address(alice), 1 ether);  
+    vm.deal(address(alice), 4 ether);  
     vm.deal(address(bob), 2 ether); 
     vm.prank(alice);
     KingOfEtherContract.claimThrone{value: 1 ether}() ;
@@ -28,6 +28,7 @@ function testDOS() public {
     console.log("Balance of KingOfEtherContract", KingOfEtherContract.balance());
     console.log("Attack completed, Alice claimthrone again, she will fail");
     vm.prank(alice);
+    vm.expectRevert("Failed to send Ether");
     KingOfEtherContract.claimThrone{value: 4 ether}() ;
   
     }


### PR DESCRIPTION
### What is the bug?
The revert message is `EvmError: OutOfFound`, which is not as intended by the POC. It should be reverted for `Failed to send Ether` to be accurate.

```
...
    ├─ [0] KingOfEther::claimThrone{value: 4000000000000000000}() 
    │   └─ ← "EvmError: OutOfFund"
    └─ ← "Call reverted as expected, but without data"
```
### Why?
User Alice in the source code should be deposited four ether to have enough funds to call `claimthrone` as normal.

### What's changed?
- I set Alice's init balance to 4 ethers.
- I add `vm.expectRevert` for a more accurate unit test.